### PR TITLE
Strategy Name with Parameters

### DIFF
--- a/TradeArcher.Core/Services/BackTestSessionImporterService.cs
+++ b/TradeArcher.Core/Services/BackTestSessionImporterService.cs
@@ -33,7 +33,15 @@ namespace TradeArcher.Core.Services
 
                             if (strategyName.Contains("("))
                             {
-                                strategyName = strategyName.Substring(0, strategyName.IndexOf("(", StringComparison.InvariantCulture));
+                                if (strategyName.Contains("]"))
+                                {
+                                    var startAt = strategyName.IndexOf("(", StringComparison.InvariantCulture);
+                                    strategyName = strategyName.Substring(startAt + 1, strategyName.IndexOf("]", StringComparison.InvariantCulture) - startAt);
+                                }
+                                else
+                                {
+                                    strategyName = strategyName.Substring(0, strategyName.IndexOf("(", StringComparison.InvariantCulture));
+                                }
                             }
 
                             var dbStrategy = context.Strategies.Include(s => s.Sessions).ThenInclude(s => s.BackTestTrades).FirstOrDefault(s => s.Name == strategyName);


### PR DESCRIPTION
Fix backtest import so it supports strategy name syntax with square brackets to show the configurable parameter settings for the strategy when it was run. e.g. `MyStrategy[8, 9, 2, 0, 10, 200]`

Note: If a square bracket is not detected, it falls back to the old logic of just grabbing the strategy name. e.g. `MyStrategy`